### PR TITLE
Fix typos in comments

### DIFF
--- a/src/movegen.cc
+++ b/src/movegen.cc
@@ -415,14 +415,14 @@ Bitboard MoveGenerator::computeCheckerMaskT(void) const {
 	// pawns
 	if constexpr (UsColor == WHITE) {
 		// we are white
-		// use white pawns beacause we are looking from the perspective of the king
+                // use white pawns because we are looking from the perspective of the king
 		checkerMask |=
 		    (WHITE_PAWN_CAPTURE_LEFT_MASK[kingSq] | WHITE_PAWN_CAPTURE_RIGHT_MASK[kingSq]) &
 		    P[PT_PAWN + 6];
 	}
 	else {
 		// we are black
-		// use black pawns beacause we are looking from the perspective of the king
+                // use black pawns because we are looking from the perspective of the king
 		checkerMask |=
 		    (BLACK_PAWN_CAPTURE_LEFT_MASK[kingSq] | BLACK_PAWN_CAPTURE_RIGHT_MASK[kingSq]) &
 		    P[PT_PAWN];

--- a/src/movelist.hpp
+++ b/src/movelist.hpp
@@ -6,7 +6,7 @@
 #include "misc.hpp"
 #include "move.hpp"
 
-// container for list of move
+// container for list of moves
 class MoveList {
    public:
 	MoveList(void) = default;

--- a/src/perft.cc
+++ b/src/perft.cc
@@ -33,7 +33,7 @@ static size_t perftT(int depth) {
 	return nodes;
 }
 
-// wrapper for perfT
+// wrapper for perft
 size_t perft(const Position &pos, int depth, bool printPerftLine) {
 	position = pos;
 	if (printPerftLine) {

--- a/src/position.cc
+++ b/src/position.cc
@@ -89,7 +89,7 @@ Position Position::fromFen(const std::string &fen, bool &success) noexcept {
 
 		if (rank != 0 || file != 8) return pos;
 
-		// occupany
+                // occupancy
 		pos.occForColor[0] = 0;
 		pos.occForColor[1] = 0;
 		for (int color = 0; color < 2; ++color) {

--- a/src/tt.cc
+++ b/src/tt.cc
@@ -53,7 +53,7 @@ void TranspositionTable::store(uint64_t key, int depth, Score value, TTFlag flag
 
 	for (int i = 0; i < CLUSTER_SIZE; ++i) {
 		TTEntry &entry = table[base + static_cast<unsigned>(i)];
-		if (entry.depth < 0 && emptyIdx < 0) {  // pick fist empty
+                if (entry.depth < 0 && emptyIdx < 0) {  // pick first empty
 			emptyIdx = i;
 		}
 		if (entry.keyTag == tag) {  // same position tag


### PR DESCRIPTION
correct spelling mistakes in comments within move generation, perft, position handling, transposition table, and move list components